### PR TITLE
chore(release): bump crate versions on `main`

### DIFF
--- a/.config/release-please-manifest.json
+++ b/.config/release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "crates/git-vendor": "0.0.0",
-  "crates/git-set-attr": "0.0.0"
+  "crates/git-vendor": "0.1.0",
+  "crates/git-set-attr": "0.1.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "git-set-attr"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "clap_mangen",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "git-vendor"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "clap_mangen",

--- a/crates/git-set-attr/CHANGELOG.md
+++ b/crates/git-set-attr/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0 (2026-03-06)
+
+
+### Features
+
+* Add CLI, executor, and library separations ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
+* Add executor pattern ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
+* Add trait implementation for `git-set-attr` ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
+* CLI scaffolding ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))

--- a/crates/git-set-attr/Cargo.toml
+++ b/crates/git-set-attr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-set-attr"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
 license.workspace = true

--- a/crates/git-vendor/CHANGELOG.md
+++ b/crates/git-vendor/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.1.0 (2026-03-06)
+
+
+### Features
+
+* Add CLI, executor, and library separations ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
+* Add merge functionality via `vendor_merge` trait implementation ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
+* Add status checks for vendors ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
+* Implement fetch and reference retrieval trait methods ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * git-set-attr bumped from 0.0.0 to 0.1.0

--- a/crates/git-vendor/Cargo.toml
+++ b/crates/git-vendor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-vendor"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
 license.workspace = true
@@ -17,6 +17,6 @@ path = "src/main.rs"
 clap.workspace = true
 clap_mangen.workspace = true
 git2.workspace = true
-git-set-attr = { version = "0.0.0", path = "../git-set-attr" }
+git-set-attr = { version = "0.1.0", path = "../git-set-attr" }
 tempfile.workspace = true
 git-filter-tree = "0.3.0"


### PR DESCRIPTION
Release Notes
---


<details><summary>git-set-attr: 0.1.0</summary>

## 0.1.0 (2026-03-06)


### Features

* Add CLI, executor, and library separations ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
* Add executor pattern ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
* Add trait implementation for `git-set-attr` ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
* CLI scaffolding ([f32efcb](https://github.com/git-ents/git-vendor/commit/f32efcb79f4d15597df08132bed7f99e212a6d47))
</details>

<details><summary>0.1.0</summary>

## 0.1.0 (2026-03-06)


### Features

* Add CLI, executor, and library separations ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
* Add merge functionality via `vendor_merge` trait implementation ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
* Add status checks for vendors ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))
* Implement fetch and reference retrieval trait methods ([08f7d2d](https://github.com/git-ents/git-vendor/commit/08f7d2dabc2ca33b71ddb181094b4d907c422a30))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * git-set-attr bumped from 0.0.0 to 0.1.0
</details>

---
This release was generated with [Release Please](https://github.com/googleapis/release-please).